### PR TITLE
Update maintenance scripts and documentation

### DIFF
--- a/elm-review-package-tests/check-previews-compile.js
+++ b/elm-review-package-tests/check-previews-compile.js
@@ -4,6 +4,7 @@ const path = require('path');
 const Ansi = require('./helpers/ansi');
 const {execSync} = require('child_process');
 const {findPreviewConfigurations} = require('./helpers/find-configurations');
+const packageDependencies = require('../elm.json').dependencies;
 
 const root = path.dirname(__dirname);
 
@@ -12,6 +13,13 @@ const root = path.dirname(__dirname);
 findPreviewConfigurations().forEach(checkThatExampleCompiles);
 
 function checkThatExampleCompiles(exampleConfiguration) {
+  const exampleConfigurationElmJson = require(`${exampleConfiguration}/elm.json`);
+
+  checkDepsAreCompatible(
+    path.basename(exampleConfiguration),
+    exampleConfigurationElmJson.dependencies.direct
+  );
+
   try {
     execSync(`npx elm-review --config ${exampleConfiguration} --report=json`, {
       encoding: 'utf8',
@@ -55,4 +63,51 @@ and make the necessary changes to make it compile.`
 
 function success(config) {
   console.log(`${Ansi.green('✔')} ${path.relative(root, config)}/ compiles`);
+}
+
+function checkDepsAreCompatible(exampleConfiguration, previewDependencies) {
+  Object.entries(packageDependencies).forEach(([depName, constraint]) => {
+    if (!(depName in previewDependencies)) {
+      console.error(
+        `Dependency ${depName} is missing in the ${exampleConfiguration}/ configuration`
+      );
+      process.exit(1);
+    }
+
+    checkConstraint(
+      exampleConfiguration,
+      depName,
+      constraint,
+      previewDependencies[depName]
+    );
+    delete previewDependencies[depName];
+  });
+
+  const remainingKeys = Object.keys(previewDependencies);
+  if (remainingKeys.length !== 0) {
+    console.error(
+      `There are extraneous dependencies in the ${exampleConfiguration}/ configuration: ${remainingKeys}`
+    );
+    process.exit(1);
+  }
+}
+
+function checkConstraint(exampleConfiguration, depName, constraint, version) {
+  const [minVersion] = constraint.split(' <= v < ').map(splitVersion);
+  const previewVersion = splitVersion(version);
+  const isValid =
+    previewVersion[0] === minVersion[0] &&
+    (previewVersion[1] > minVersion[1] ||
+      (previewVersion[1] === minVersion[1] &&
+        previewVersion[2] >= minVersion[2]));
+  if (!isValid) {
+    console.error(
+      `The constraint for ${depName} in ${exampleConfiguration}/ is not in the expected range. It was ${version} but it should be in ${constraint} to be in sync with the package's elm.json's dependencies.`
+    );
+    process.exit(1);
+  }
+}
+
+function splitVersion(version) {
+  return version.split('.').map((n) => Number.parseInt(n, 10));
 }

--- a/elm-tooling.json
+++ b/elm-tooling.json
@@ -1,7 +1,6 @@
 {
     "tools": {
         "elm": "0.19.1",
-        "elm-format": "0.8.5",
-        "elm-json": "0.2.10"
+        "elm-format": "0.8.5"
     }
 }

--- a/example/elm.json
+++ b/example/elm.json
@@ -6,29 +6,29 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "Arkham/elm-review-no-missing-type-constructor": "1.0.0",
-            "elm/browser": "1.0.2",
             "elm/core": "1.0.5",
-            "elm/html": "1.0.0",
-            "jfmengels/elm-review": "2.3.11"
+            "jfmengels/elm-review": "2.3.11",
+            "stil4m/elm-syntax": "7.2.1",
+            "Arkham/elm-review-no-missing-type-constructor": "1.0.1"
         },
         "indirect": {
+            "elm/html": "1.0.0",
             "elm/json": "1.1.3",
             "elm/parser": "1.1.0",
             "elm/project-metadata-utils": "1.0.1",
             "elm/random": "1.0.0",
             "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
             "elm/virtual-dom": "1.0.2",
             "elm-community/list-extra": "8.3.0",
             "elm-explorations/test": "1.2.2",
             "rtfeldman/elm-hex": "1.0.0",
-            "stil4m/elm-syntax": "7.2.1",
             "stil4m/structured-writer": "1.0.3"
         }
     },
     "test-dependencies": {
-        "direct": {},
+        "direct": {
+            "elm-explorations/test": "1.2.2"
+        },
         "indirect": {}
     }
 }

--- a/example/src/ReviewConfig.elm
+++ b/example/src/ReviewConfig.elm
@@ -2,9 +2,13 @@ module ReviewConfig exposing (config)
 
 {-| Do not rename the ReviewConfig module or the config function, because
 `elm-review` will look for these.
+
 To add packages that contain rules, add them to this review project using
-`elm install author/packagename`
+
+    `elm install author/packagename`
+
 when inside the directory containing this file.
+
 -}
 
 import NoMissingTypeConstructor

--- a/maintenance/MAINTENANCE.md
+++ b/maintenance/MAINTENANCE.md
@@ -17,17 +17,17 @@ This document and the set up created for you is aimed at helping you work and im
 
 Right after you have created the package, you should
 
-1. Install the `npm` dependencies
+### 1. Install the `npm` dependencies
 
 ```bash
 npm install
-# or if you have and prefer Yarn
-yarn
 ```
+
+If you prefer using `yarn` or another package manager, you can do so, but you should update the 2 "Install npm dependencies" scripts in `.github/workflows/test.yml` so that they use your preferred package manager.
 
 Note that [`elm-tooling`](https://elm-tooling.github.io/elm-tooling-cli/) takes care of some of the Elm dependencies, notably `elm` and `elm-format`. Their versions are defined in the `elm-tooling.json` file, and are automatically installed through the `postinstall` script/hook in `package.json`.
 
-2. Set up `Git`
+### 2. Set up `Git`
 
 ```bash
 git init
@@ -35,19 +35,23 @@ git add --all
 git commit --message="Initialize project"
 ```
 
-3. Create the project on GitHub
-
-You can do this step at a later time if you prefer.
-When you do, consider adding the `elm-review` tag, so that your project appears in [this list](https://github.com/topics/elm-review).
-
-
-4. Replace REPLACEME
+### 3. Replace REPLACEME
 
 In some of the files, notably `elm.json`, `README.md` and the rule files that were created for you, you will find a few `REPLACEME`. You will need to replace all of these and by things that make sense in their individual context.
 
 Again, you can do this step at a later time if you prefer, but you will have to do these before publishing. You will be reminded to do this when running the tests.
 
 Note that you will also have to supply the `summary` field in the `elm.json`, which should be close to the same thing that you will write in the README.
+
+### 4. (Can be done later) Create the project on GitHub
+
+You can do this step at a later time if you prefer.
+When you do, consider to
+
+- Adding the `elm-review` tag, so that your project appears in [this list](https://github.com/topics/elm-review).
+- [Adding a code of conduct](https://docs.github.com/en/github/building-a-strong-community/adding-a-code-of-conduct-to-your-project)
+- [Adding issue and pull request templates](https://docs.github.com/en/github/building-a-strong-community/using-templates-to-encourage-useful-issues-and-pull-requests)
+- [Setting guidelines for repository contributors](https://docs.github.com/en/github/building-a-strong-community/setting-guidelines-for-repository-contributors)
 
 
 ## Writing rules
@@ -113,23 +117,12 @@ Contrary to the initial release, the CI will automatically try to publish a new 
 Here is a script that you can run to publish your package, which will help you avoid errors showing up at the CI stage.
 
 ```bash
-# Bump the version of the package
-elm bump
-
-# Run elm-review, which will for instance auto-fix like documentation links
-elm-review --fix-all
-
-# Run the tests, fix them if necessary
-npm test
-
-# Update the example configurations to reflect what was previously in the
-# preview configurations
-node maintenance/update-examples-from-preview.js
+npm run elm-bump
 
 # Commit it all
 git add --all
-git commit
+git commit # You'll need to specify a message
 git push origin HEAD
 
-# Now wait for CI to finish
+# Now wait for CI to finish and check that it succeeded
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,4 @@
 {
-  "name": "elm-review-no-missing-type-constructor",
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "elm-review-no-missing-type-constructor",
+  "name": "",
   "scripts": {
     "test": "npm-run-all --print-name --silent --sequential test:make test:format test:run test:review test:package",
     "test:make": "elm make --docs=docs.json",
@@ -8,12 +8,16 @@
     "test:review": "elm-review",
     "test:package": "node elm-review-package-tests/check-previews-compile.js",
     "preview-docs": "elm-doc-preview",
+    "elm-bump": "npm-run-all --print-name --silent --sequential test bump-version 'test:review -- --fix-all-without-prompt' update-examples",
+    "bump-version": "(yes | elm bump)",
+    "update-examples": "node maintenance/update-examples-from-preview.js",
     "postinstall": "elm-tooling install"
   },
   "dependencies": {
     "elm-doc-preview": "^5.0.3",
     "elm-review": "^2.4.6",
     "elm-test": "^0.19.1-revision6",
+    "elm-tooling": "^1.3.0",
     "fs-extra": "9.0.0",
     "glob": "7.1.6",
     "npm-run-all": "^4.1.5"

--- a/preview/elm.json
+++ b/preview/elm.json
@@ -8,14 +8,14 @@
     "dependencies": {
         "direct": {
             "elm/core": "1.0.5",
-            "elm/json": "1.1.3",
-            "elm/project-metadata-utils": "1.0.1",
             "jfmengels/elm-review": "2.3.11",
             "stil4m/elm-syntax": "7.2.1"
         },
         "indirect": {
             "elm/html": "1.0.0",
+            "elm/json": "1.1.3",
             "elm/parser": "1.1.0",
+            "elm/project-metadata-utils": "1.0.1",
             "elm/random": "1.0.0",
             "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.2",


### PR DESCRIPTION
- Update maintenance scripts and documentation with what you'd get with `elm-review new-package` (in the latest or upcoming version, I don't remember)
- Remove unnecessary dependencies in preview configuration 
- Updates the example configuration based on preview configuration (this currently makes the CI fail).

Next time you aim to publish, you can do `npm run elm-bump`, commit and push :relaxed: 