### PR TITLE
Include errorWithFix for missing type constructors

### DIFF
--- a/src/NoMissingTypeConstructor.elm
+++ b/src/NoMissingTypeConstructor.elm
@@ -27,6 +27,7 @@ import Elm.Syntax.Declaration as Declaration exposing (Declaration)
 import Elm.Syntax.Expression as Expression exposing (Expression)
 import Elm.Syntax.ModuleName exposing (ModuleName)
 import Elm.Syntax.Node as Node exposing (Node)
+import Elm.Syntax.Range as Range
 import Elm.Syntax.Type exposing (Type)
 import Elm.Syntax.TypeAnnotation as TypeAnnotation exposing (TypeAnnotation)
 import Review.Fix
@@ -312,16 +313,19 @@ addMissingConstructors :
     -> Review.Fix.Fix
 addMissingConstructors { missingConstructors, usedConstructors } function =
     let
+        listDeclarationExpression : Node Expression
         listDeclarationExpression =
             function.declaration
                 |> Node.value
                 |> .expression
 
+        endOfList : Range.Location
         endOfList =
             listDeclarationExpression
                 |> Node.range
                 |> .end
 
+        afterLastOption : { column : Int, row : Int }
         afterLastOption =
             case lastItemDeclared listDeclarationExpression of
                 Nothing ->

--- a/src/NoMissingTypeConstructor.elm
+++ b/src/NoMissingTypeConstructor.elm
@@ -29,6 +29,7 @@ import Elm.Syntax.ModuleName exposing (ModuleName)
 import Elm.Syntax.Node as Node exposing (Node)
 import Elm.Syntax.Type exposing (Type)
 import Elm.Syntax.TypeAnnotation as TypeAnnotation exposing (TypeAnnotation)
+import Review.Fix
 import Review.ModuleNameLookupTable as ModuleNameLookupTable exposing (ModuleNameLookupTable)
 import Review.Rule as Rule exposing (Error, Rule)
 import Set exposing (Set)
@@ -201,7 +202,7 @@ declarationVisitor declaration context =
                                     )
 
                                 else
-                                    ( [ Rule.error
+                                    ( [ Rule.errorWithFix
                                             { message = "`" ++ Node.value functionName ++ "` does not contain all the type constructors for `" ++ typeName ++ "`"
                                             , details =
                                                 [ "We expect `" ++ Node.value functionName ++ "` to contain all the type constructors for `" ++ typeName ++ "`."
@@ -211,6 +212,12 @@ declarationVisitor declaration context =
                                                 ]
                                             }
                                             (Node.range functionName)
+                                            [ addMissingConstructors
+                                                { missingConstructors = missingConstructors
+                                                , usedConstructors = usedConstructors
+                                                }
+                                                function
+                                            ]
                                       ]
                                     , context
                                     )
@@ -283,3 +290,57 @@ getListOfTypeAnnotation lookupTable typeAnnotation =
 
         _ ->
             Nothing
+
+
+lastItemDeclared : Node Expression -> Maybe (Node Expression)
+lastItemDeclared listOfItemsExpression =
+    case Node.value listOfItemsExpression of
+        Expression.ListExpr items ->
+            items
+                |> List.reverse
+                |> List.head
+
+        _ ->
+            Nothing
+
+
+addMissingConstructors :
+    { missingConstructors : Set String
+    , usedConstructors : Set String
+    }
+    -> Expression.Function
+    -> Review.Fix.Fix
+addMissingConstructors { missingConstructors, usedConstructors } function =
+    let
+        listDeclarationExpression =
+            function.declaration
+                |> Node.value
+                |> .expression
+
+        endOfList =
+            listDeclarationExpression
+                |> Node.range
+                |> .end
+
+        afterLastOption =
+            case lastItemDeclared listDeclarationExpression of
+                Nothing ->
+                    -- If there are no options, insert just before the end of the list `]`.
+                    { endOfList
+                        | column = endOfList.column - 1
+                    }
+
+                Just lastItemDeclared_ ->
+                    Node.range lastItemDeclared_
+                        |> .end
+    in
+    Review.Fix.insertAt
+        afterLastOption
+        ((if Set.size usedConstructors > 0 then
+            ", "
+
+          else
+            " "
+         )
+            ++ (missingConstructors |> Set.toList |> String.join ", ")
+        )

--- a/tests/NoMissingTypeConstructorTest.elm
+++ b/tests/NoMissingTypeConstructorTest.elm
@@ -28,6 +28,12 @@ allThings = [ A, C, B ]
                             , under = "allThings"
                             }
                             |> Review.Test.atExactly { start = { row = 4, column = 1 }, end = { row = 4, column = 10 } }
+                            |> Review.Test.whenFixed
+                                """module A exposing (..)
+type Thing = A | B | C | D | E
+allThings : List Thing
+allThings = [ A, C, B, D, E ]
+"""
                         ]
         , test "should report when a declaration named `all...` that is of type `List <CustomTypeName>` does not have all the type constructors in its value (2)" <|
             \_ ->
@@ -48,6 +54,12 @@ allShenanigans = [ FirstThing, ThirdThing ]
                             , under = "allShenanigans"
                             }
                             |> Review.Test.atExactly { start = { row = 4, column = 1 }, end = { row = 4, column = 15 } }
+                            |> Review.Test.whenFixed
+                                """module A exposing (..)
+type Shenanigan = FirstThing | SecondThing | ThirdThing
+allShenanigans : List Shenanigan
+allShenanigans = [ FirstThing, ThirdThing, SecondThing ]
+"""
                         ]
         , test "should report when a declaration named `all...` that is of type `List <CustomTypeName>` does not have all the type constructors in its value, where type is defined in a different module" <|
             \_ ->
@@ -71,6 +83,12 @@ type Shenanigan = FirstThing | SecondThing | ThirdThing
                                 , under = "allShenanigans"
                                 }
                                 |> Review.Test.atExactly { start = { row = 4, column = 1 }, end = { row = 4, column = 15 } }
+                                |> Review.Test.whenFixed
+                                    """module A exposing (..)
+import CustomTypeHolder exposing (..)
+allShenanigans : List Shenanigan
+allShenanigans = [ FirstThing, ThirdThing, SecondThing ]
+"""
                             ]
                           )
                         ]
@@ -123,4 +141,34 @@ someOfTheThings = [ A, C, B ]
 """
                     |> Review.Test.run rule
                     |> Review.Test.expectNoErrors
+        , test "should fix when a declaration named `all` that is of type `List <CustomTypeName>` does not have ANY of the type constructors in its value" <|
+            \_ ->
+                """module A exposing (..)
+type Thing = A | B | C | D | E
+all : List Thing
+all = []
+"""
+                    |> Review.Test.run rule
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "`all` does not contain all the type constructors for `Thing`"
+                            , details =
+                                [ "We expect `all` to contain all the type constructors for `Thing`."
+                                , """In this case, you are missing the following constructors:
+    , A
+    , B
+    , C
+    , D
+    , E"""
+                                ]
+                            , under = "all"
+                            }
+                            |> Review.Test.atExactly { start = { row = 4, column = 1 }, end = { row = 4, column = 4 } }
+                            |> Review.Test.whenFixed
+                                """module A exposing (..)
+type Thing = A | B | C | D | E
+all : List Thing
+all = [ A, B, C, D, E]
+"""
+                        ]
         ]


### PR DESCRIPTION
Thanks for making this rule! Here's support for `--fix`.

## Example

Before fix
```elm
module A exposing (..)
type Thing = A | B | C | D | E
allThings : List Thing
allThings = [ A, C, B ]
```

After fix
```elm
module A exposing (..)
type Thing = A | B | C | D | E
allThings : List Thing
allThings = [ A, C, B, D, E ]
```