### PR TITLE
Add support for Nonempty lists

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -10,10 +10,10 @@
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
         "elm/core": "1.0.5 <= v < 2.0.0",
-        "jfmengels/elm-review": "2.3.0 <= v < 3.0.0",
-        "stil4m/elm-syntax": "7.2.1 <= v < 8.0.0"
+        "jfmengels/elm-review": "2.13.1 <= v < 3.0.0",
+        "stil4m/elm-syntax": "7.2.9 <= v < 8.0.0"
     },
     "test-dependencies": {
-        "elm-explorations/test": "1.2.2 <= v < 2.0.0"
+        "elm-explorations/test": "2.0.0 <= v < 3.0.0"
     }
 }

--- a/src/NoMissingTypeConstructor.elm
+++ b/src/NoMissingTypeConstructor.elm
@@ -73,6 +73,7 @@ rule =
             , foldProjectContexts = foldProjectContexts
             }
         |> Rule.withContextFromImportedModules
+        |> Rule.providesFixesForProjectRule
         |> Rule.fromProjectRuleSchema
 
 


### PR DESCRIPTION
I've added support for nonempty lists.

So this code gets reported
```elm
type Color
    = Red
    | Green
    | Blue

allColors : Nonempty Color
allColors =
    Nonempty Red [ Green ]
```
with this fixed code provided
```elm
type Color
    = Red
    | Green
    | Blue

allColors : Nonempty Color
allColors =
    Nonempty Red [ Green, Blue ]
```

It was built with [mgold/elm-nonempty-list](https://package.elm-lang.org/packages/mgold/elm-nonempty-list/latest/) in mind but it should also handle any types called Nonempty or NonEmpty